### PR TITLE
Handle old and new metric object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -119,10 +119,20 @@ module.exports = class PrometheusMetricsConsumer extends Writable {
                 registry: this.registry,
             });
         }
-        this.registry
-            .getSingleMetric(name)
-            .labels(...labelValues)
-            .observe(time);
+
+        if (metric.type && metric.type === 7) {
+            // new metric object with type
+            this.registry
+                .getSingleMetric(name)
+                .labels(...labelValues)
+                .observe(metric.value);
+        } else {
+            // old metric object without type
+            this.registry
+                .getSingleMetric(name)
+                .labels(...labelValues)
+                .observe(time);
+        }
     }
 
     override(name, config) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -103,10 +103,20 @@ module.exports = class PrometheusMetricsConsumer extends Writable {
                 registry: this.registry,
             });
         }
-        this.registry
-            .getSingleMetric(name)
-            .labels(...labelValues)
-            .observe(time);
+
+        if (metric.type && metric.type === 5) {
+            // new metric object with type
+            this.registry
+                .getSingleMetric(name)
+                .labels(...labelValues)
+                .observe(metric.value);
+        } else {
+            // old metric object without type
+            this.registry
+                .getSingleMetric(name)
+                .labels(...labelValues)
+                .observe(time);
+        }
     }
 
     summary(metric) {


### PR DESCRIPTION
The old metric object set timing values on the `.time` property while the new metric sets the same value on `.value`. Here we use `.type` which was introduce between old and new metric object to check if the object are old or new.