### PR TITLE
catch and log errors when generating prom client metrics

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Joi = require('joi');
+const abslog = require('abslog');
 const { Writable } = require('readable-stream');
 const {
     createCounter,
@@ -55,6 +56,7 @@ module.exports = class PrometheusMetricsConsumer extends Writable {
         this.Summary = client.Summary;
         this.bucketFunction = client.exponentialBuckets;
         this.registry = new client.Registry();
+        this.logger = abslog(options.logger);
     }
 
     get [Symbol.toStringTag]() {
@@ -205,13 +207,49 @@ module.exports = class PrometheusMetricsConsumer extends Writable {
 
     _write(metric, enc, cb) {
         if (this.typeFor(metric) === metricTypes.HISTOGRAM) {
-            this.histogram(metric);
+            try {
+                this.histogram(metric);
+            } catch (err) {
+                this.logger.error(
+                    `failed to generate prometheus histogram for metric "${JSON.stringify(
+                        metric,
+                    )}"`,
+                    err,
+                );
+            }
         } else if (this.typeFor(metric) === metricTypes.GAUGE) {
-            this.gauge(metric);
+            try {
+                this.gauge(metric);
+            } catch (err) {
+                this.logger.error(
+                    `failed to generate prometheus gauge for metric "${JSON.stringify(
+                        metric,
+                    )}"`,
+                    err,
+                );
+            }
         } else if (this.typeFor(metric) === metricTypes.SUMMARY) {
-            this.summary(metric);
+            try {
+                this.summary(metric);
+            } catch (err) {
+                this.logger.error(
+                    `failed to generate prometheus summary metric for "${JSON.stringify(
+                        metric,
+                    )}"`,
+                    err,
+                );
+            }
         } else {
-            this.counter(metric);
+            try {
+                this.counter(metric);
+            } catch (err) {
+                this.logger.error(
+                    `failed to generate prometheus counter for metric "${JSON.stringify(
+                        metric,
+                    )}"`,
+                    err,
+                );
+            }
         }
         cb();
     }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     },
     "author": "Richard Walker <digitalsadhu@gmail.com>",
     "dependencies": {
+        "abslog": "^2.4.0",
         "joi": "^14.0.0",
         "readable-stream": "^3.1.1"
     },

--- a/schemas/constructor-options.js
+++ b/schemas/constructor-options.js
@@ -4,6 +4,7 @@ const Joi = require('joi');
 
 module.exports = Joi.object()
     .keys({
+        logger: Joi.object(),
         client: Joi.object()
             .keys({
                 Gauge: Joi.func(),

--- a/schemas/index.js
+++ b/schemas/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable global-require */
+
 'use strict';
 
 module.exports = {


### PR DESCRIPTION
This PR hardens up the consumer such that:

A. prom client explosions wont take down the server
B. we get better logging of what prom client didn't like and can fix elsewhere