### PR TITLE
fix: add registry field to types and fix client from any

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "eslint-plugin-prettier": "3.4.1",
         "lint-staged": "10.5.4",
         "prettier": "2.8.8",
-        "prom-client": "13.2.0",
+        "prom-client": "14.2.0",
         "tap": "16.3.8"
     }
 }

--- a/prometheus-consumer.d.ts
+++ b/prometheus-consumer.d.ts
@@ -1,6 +1,6 @@
 import { Writable } from 'readable-stream';
 import { AbstractLogger } from 'abslog';
-import PrometheusClient, { Registry } from 'prom-client';
+import * as PrometheusClient from 'prom-client';
 
 declare class PrometheusConsumer extends Writable {
     constructor(options: PrometheusConsumer.PrometheusConsumerOptions);
@@ -9,13 +9,14 @@ declare class PrometheusConsumer extends Writable {
         metric: string,
         config: PrometheusConsumer.PrometheusConsumerOverrideConfig,
     ): void;
-    metrics(): ReturnType<Registry['metrics']>;
-    contentType(): Registry['contentType'];
+    readonly registry: PrometheusClient.Registry;
+    metrics(): ReturnType<PrometheusClient.Registry['metrics']>;
+    contentType(): PrometheusClient.Registry['contentType'];
 }
 
 declare namespace PrometheusConsumer {
     export type PrometheusConsumerOptions = {
-        client: PrometheusClient;
+        client: typeof PrometheusClient;
         logger?: AbstractLogger;
         bucketStepFactor?: number;
         bucketStepCount?: number;


### PR DESCRIPTION
Used when merging registries, for instance

```js
Registry.merge([
    this.#consumer?.registry,
    this.#options.prometheus?.register,
]);
```