### PR TITLE
Fixes invalid error logging

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -249,10 +249,10 @@ module.exports = class PrometheusMetricsConsumer extends Writable {
                 this.histogram(metric);
             } catch (err) {
                 this.logger.error(
+                    err,
                     `failed to generate prometheus histogram for metric "${JSON.stringify(
                         metric,
                     )}"`,
-                    err,
                 );
             }
         } else if (this.typeFor(metric) === metricTypes.GAUGE) {
@@ -260,10 +260,10 @@ module.exports = class PrometheusMetricsConsumer extends Writable {
                 this.gauge(metric);
             } catch (err) {
                 this.logger.error(
+                    err,
                     `failed to generate prometheus gauge for metric "${JSON.stringify(
                         metric,
                     )}"`,
-                    err,
                 );
             }
         } else if (this.typeFor(metric) === metricTypes.SUMMARY) {
@@ -271,10 +271,10 @@ module.exports = class PrometheusMetricsConsumer extends Writable {
                 this.summary(metric);
             } catch (err) {
                 this.logger.error(
+                    err,
                     `failed to generate prometheus summary metric for "${JSON.stringify(
                         metric,
                     )}"`,
-                    err,
                 );
             }
         } else {
@@ -282,10 +282,10 @@ module.exports = class PrometheusMetricsConsumer extends Writable {
                 this.counter(metric);
             } catch (err) {
                 this.logger.error(
+                    err,
                     `failed to generate prometheus counter for metric "${JSON.stringify(
                         metric,
                     )}"`,
-                    err,
                 );
             }
         }


### PR DESCRIPTION
This PR resolves issue #93 which describes how the error logging does not follow the contract of `abslog` and thereby removing the error from the log if using a logger like pino.

Closes https://github.com/metrics-js/prometheus-consumer/issues/93